### PR TITLE
Fix/posixpath migration error

### DIFF
--- a/pokerstore/settings.py
+++ b/pokerstore/settings.py
@@ -77,7 +77,7 @@ WSGI_APPLICATION = 'pokerstore.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
+        'NAME': str(BASE_DIR / 'db.sqlite3'),
     }
 }
 


### PR DESCRIPTION
Fix error `TypeError: argument of type 'PosixPath' is not iterable` at running django migration using sqlite
<img width="1151" alt="image" src="https://github.com/Dagujap/pokerstore/assets/6877840/7d9a468f-106f-4788-8954-917f26a365dc">


Database name must be parsed to string `str(BASE_DIR / 'db.sqlite3')`
<img width="497" alt="image" src="https://github.com/Dagujap/pokerstore/assets/6877840/086f410a-4e7b-403b-bc8b-a7b541f960f8">
